### PR TITLE
extending app document

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Navbar from "../Navbar/Navbar";
+
+/* En react 18 children fue eliminado del tipo FC, 
+para que typescript no de error debes de añadirlo por cuenta propia */
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const Layout: React.FC<Props> = ({children}) => {
+  return (
+    <div>
+      <Navbar />
+      {children}
+      <footer>Footer</footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,10 @@
+import type { AppProps } from "next/app";
+import Layout from "../components/Layout/Layout";
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import Navbar from "../../components/Navbar/Navbar";
 
 
 const AboutPage = () => {
   return (
     <div>
-      <Navbar/>
-      <h1>About</h1>
+      <h1>sobre los aguacates</h1>
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import Navbar from "../components/Navbar/Navbar";
 
 import styled from "styled-components";
 
@@ -16,7 +15,6 @@ const Home = () => {
 
   return (
     <Wrapper>
-      <Navbar />
       <h1>Platzi and Next.js!</h1>
       {productList.map((item) => (
         <div key={item.id}>{item.name}</div>


### PR DESCRIPTION
This commit we have a new document named `_app` and this document control the whole app, in this file we gonna put a `Layout ` component. This `Layout` has inside, our header and footer.

there we gonna past the header , footer and children by whole app, and children means whatever page that we have in the app